### PR TITLE
Atomics fixes

### DIFF
--- a/src/a.tex
+++ b/src/a.tex
@@ -529,5 +529,5 @@ success guarantee may slow down concurrent loads from the same effective
 address. A sequentially consistent store can be implemented as an AMOSWAP
 that writes the old value to x0 and has {\em rl} set. However the superfluous
 load may impose ordering constraints that are unnecessary for this use case.
-Specific comilation conventions may require both the {\em aq} and {\em rl}
+Specific compilation conventions may require both the {\em aq} and {\em rl}
 bits to be set in either or both the LR and AMOSWAP instructions.

--- a/src/a.tex
+++ b/src/a.tex
@@ -232,9 +232,10 @@ before the LR instruction that established the reservation.
 The LR/SC
 sequence can be given acquire semantics by setting the {\em aq} bit on
 the LR instruction.  The LR/SC sequence can be given release semantics
-by setting the {\em rl} bit on the SC instruction.  Setting the
+by setting the {\em rl} bit on the SC instruction.  Assuming
+suitable mappings for other atomic operations, setting the
 {\em aq} bit on the LR instruction, and setting the
-{\em rl} bit on the SC instruction potentially makes the LR/SC
+{\em rl} bit on the SC instruction makes the LR/SC
 sequence sequentially consistent in the C++ {\em memory_order_seq_cst}
 sense. Such a sequence does not act as a fence for ordering ordinary
 load and store instructions before and after the sequence. Specific
@@ -522,9 +523,10 @@ elision~\cite{Rajwar:2001:SLE}.
 \end{commentary}
 
 The instructions in the ``A'' extension can be used to provide sequentially
-consistent loads and stores, but this constrains the implementation more
-than absolutely necessary.  A C++ sequentially consistent load can
-be implemented as an LR with {\em aq} set. However, the LR/SC eventual
+consistent loads and stores, but this constrains hardware
+reordering of memory accesses more than necessary.
+A C++ sequentially consistent load can be implemented as
+an LR with {\em aq} set. However, the LR/SC eventual
 success guarantee may slow down concurrent loads from the same effective
 address. A sequentially consistent store can be implemented as an AMOSWAP
 that writes the old value to x0 and has {\em rl} set. However the superfluous

--- a/src/a.tex
+++ b/src/a.tex
@@ -232,16 +232,17 @@ before the LR instruction that established the reservation.
 The LR/SC
 sequence can be given acquire semantics by setting the {\em aq} bit on
 the LR instruction.  The LR/SC sequence can be given release semantics
-by setting the {\em rl} bit on the SC instruction.  Setting the {\em
-  aq} bit on the LR instruction, and setting the {\em
-  rl} bit on the SC instruction makes the LR/SC sequence sequentially
-consistent in the C++ sense, meaning that it cannot be reordered with
-earlier or later memory operations from the same hart. Specific instruction
-mappings for other C++ atomic operations may require both bits to be set
-on either the LR or SC instruction for proper interoperation with those
-operations.
+by setting the {\em rl} bit on the SC instruction.  Setting the
+{\em aq} bit on the LR instruction, and setting the
+{\em rl} bit on the SC instruction potentially makes the LR/SC
+sequence sequentially consistent in the C++ {\em memory_order_seq_cst}
+sense. Such a sequence does not act as a fence for ordering ordinary
+load and store instructions before and after the sequence. Specific
+instruction mappings for other C++ atomic operations,
+or stronger notions of "sequential consistency", may require both
+bits to be set on either or both of the LR or SC instruction.
 
-If neither bit is set on both LR and SC, the LR/SC sequence can be
+If neither bit is set on either LR or SC, the LR/SC sequence can be
 observed to occur before or after surrounding memory operations from
 the same RISC-V hart.  This can be appropriate when the LR/SC
 sequence is used to implement a parallel reduction operation.

--- a/src/a.tex
+++ b/src/a.tex
@@ -233,10 +233,13 @@ The LR/SC
 sequence can be given acquire semantics by setting the {\em aq} bit on
 the LR instruction.  The LR/SC sequence can be given release semantics
 by setting the {\em rl} bit on the SC instruction.  Setting the {\em
-  aq} bit on the LR instruction, and setting both the {\em aq} and the {\em
+  aq} bit on the LR instruction, and setting the {\em
   rl} bit on the SC instruction makes the LR/SC sequence sequentially
-consistent, meaning that it cannot be reordered with earlier or
-later memory operations from the same hart.
+consistent in the C++ sense, meaning that it cannot be reordered with
+earlier or later memory operations from the same hart. Specific instruction
+mappings for other C++ atomic operations may require both bits to be set
+on either the LR or SC instruction for proper interoperation with those
+operations.
 
 If neither bit is set on both LR and SC, the LR/SC sequence can be
 observed to occur before or after surrounding memory operations from

--- a/src/a.tex
+++ b/src/a.tex
@@ -517,8 +517,11 @@ acquire and release to simplify the implementation of speculative lock
 elision~\cite{Rajwar:2001:SLE}.
 \end{commentary}
 
-The instructions in the ``A'' extension can also be used to provide
-sequentially consistent loads and stores.  A sequentially consistent load can
-be implemented as an LR with both {\em aq} and {\em rl} set. A sequentially
-consistent store can be implemented as an AMOSWAP that writes the old value to
-x0 and has both {\em aq} and {\em rl} set.
+The instructions in the ``A'' extension can be used to provide sequentially
+consistent loads and stores, but this constrains the implementation more
+than absolutely necessary.  A C++ sequentially consistent load can
+be implemented as an LR with {\em aq} set. However, the LR/SC eventual
+success guarantee may slow down concurrent loads from the same effective
+address. A sequentially consistent store can be implemented as an AMOSWAP
+that writes the old value to x0 and has {\em rl} set. However the superfluous
+load may impose ordering constraints that are unnecessary for this use case.

--- a/src/a.tex
+++ b/src/a.tex
@@ -528,3 +528,5 @@ success guarantee may slow down concurrent loads from the same effective
 address. A sequentially consistent store can be implemented as an AMOSWAP
 that writes the old value to x0 and has {\em rl} set. However the superfluous
 load may impose ordering constraints that are unnecessary for this use case.
+Specific comilation conventions may require both the {\em aq} and {\em rl}
+bits to be set in either or both the LR and AMOSWAP instructions.

--- a/src/a.tex
+++ b/src/a.tex
@@ -239,7 +239,7 @@ sequence sequentially consistent in the C++ {\em memory_order_seq_cst}
 sense. Such a sequence does not act as a fence for ordering ordinary
 load and store instructions before and after the sequence. Specific
 instruction mappings for other C++ atomic operations,
-or stronger notions of "sequential consistency", may require both
+or stronger notions of ``sequential consistency'', may require both
 bits to be set on either or both of the LR or SC instruction.
 
 If neither bit is set on either LR or SC, the LR/SC sequence can be

--- a/src/memory.tex
+++ b/src/memory.tex
@@ -1224,7 +1224,7 @@ That said, these mappings are subject to change as the Linux Kernel Memory Model
 
 Table~\ref{tab:c11mappings} provides a mapping of C11/C++11 atomic operations onto RISC-V memory instructions.
 If load and store opcodes with {\em aq} and {\em rl} modifiers are introduced, then the mappings in Table~\ref{tab:c11mappings_hypothetical} will suffice.
-Note however that the two mappings only interoperate correctly if {\tt atomic\_<op>(memory\_order\_seq\_cst)} is mapped using an LR that has both {\em aq} and {\em rl} set.
+Note however that the two mappings only interoperate correctly if {\tt atomic\_<op>(memory\_order\_seq\_cst)} is mapped using an LR that has both {\em aq} and {\em rl} set. Even more importantly, an A.6 sequentially consistent store, followed by an A.7 sequentially consistent load can be reordered unless the A.6 mapping of stores is strengthened by either adding a second fence or mapping the store to amoswap.rl instead.
 
 Any AMO can be emulated by an LR/SC pair, but care must be taken to ensure that any PPO orderings that originate from the LR are also made to originate from the SC, and that any PPO orderings that terminate at the SC are also made to terminate at the LR.
 For example, the LR must also be made to respect any data dependencies that the AMO has, given that load operations do not otherwise have any notion of a data dependency.

--- a/src/memory.tex
+++ b/src/memory.tex
@@ -1224,7 +1224,8 @@ That said, these mappings are subject to change as the Linux Kernel Memory Model
 
 Table~\ref{tab:c11mappings} provides a mapping of C11/C++11 atomic operations onto RISC-V memory instructions.
 If load and store opcodes with {\em aq} and {\em rl} modifiers are introduced, then the mappings in Table~\ref{tab:c11mappings_hypothetical} will suffice.
-Note however that the two mappings only interoperate correctly if {\tt atomic\_<op>(memory\_order\_seq\_cst)} is mapped using an LR that has both {\em aq} and {\em rl} set. Even more importantly, an A.6 sequentially consistent store, followed by an A.7 sequentially consistent load can be reordered unless the A.6 mapping of stores is strengthened by either adding a second fence or mapping the store to amoswap.rl instead.
+Note however that the two mappings only interoperate correctly if {\tt atomic\_<op>(memory\_order\_seq\_cst)} is mapped using an LR that has both {\em aq} and {\em rl} set.
+Even more importantly, a Table~\ref{tab:c11mappings} sequentially consistent store, followed by a Table~\ref{tab:c11mappings_hypothetical} sequentially consistent load can be reordered unless the Table~\ref{tab:c11mappings} mapping of stores is strengthened by either adding a second fence or mapping the store to {\tt amoswap.rl} instead.
 
 Any AMO can be emulated by an LR/SC pair, but care must be taken to ensure that any PPO orderings that originate from the LR are also made to originate from the SC, and that any PPO orderings that terminate at the SC are also made to terminate at the LR.
 For example, the LR must also be made to respect any data dependencies that the AMO has, given that load operations do not otherwise have any notion of a data dependency.


### PR DESCRIPTION
This is a fairly minimal fix to the unprivileged spec to prepare us for atomics ABI work. It fixes some oversimplifications that were uncovered during the load-acquire store-release mailing list discussions. Some of the observations behind the changes came from Palmer Dabbelt. Andrea Parri, and others. It also fixes some inconsistencies with A.6, and adds a clarification there.

Note that the use of LR/SC to implement "sequentially consistent" atomics primitives is subtle, and depends on the precise semantics, and how other atomics are implemented. I tried to tread the fine line between inaccuracy and turning this into a memory model tutorial